### PR TITLE
Handle NaN in raw json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container:
-        image: quantconnect/lean:foundation
+    
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Free space
+        run: df -h && rm -rf /opt/hostedtoolcache* && df -h
+
+      - name: Pull Foundation Image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quantconnect/lean:foundation
 
       - name: BuildDataSource
         run: dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1

--- a/DataProcessing/QuiverWikipediaDataDownloader.cs
+++ b/DataProcessing/QuiverWikipediaDataDownloader.cs
@@ -426,14 +426,7 @@ namespace QuantConnect.DataProcessing
 
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
-            if (value == null)
-                writer.WriteNull();
-            else if (value is double d && Double.IsNaN(d))
-                writer.WriteNull();
-            else if (value is float f && Single.IsNaN(f))
-                writer.WriteNull();
-            else
-                writer.WriteValue(value);
+            throw new NotImplementedException();
         }
     }
 }

--- a/DataProcessing/QuiverWikipediaDataDownloader.cs
+++ b/DataProcessing/QuiverWikipediaDataDownloader.cs
@@ -391,6 +391,8 @@ namespace QuantConnect.DataProcessing
 
     public class NoNanRealConverter : JsonConverter
     {
+        public override bool CanWrite => False;
+        
         public override bool CanConvert(Type objectType)
         {
             var type = Nullable.GetUnderlyingType(objectType) ?? objectType;

--- a/DataProcessing/QuiverWikipediaDataDownloader.cs
+++ b/DataProcessing/QuiverWikipediaDataDownloader.cs
@@ -391,7 +391,7 @@ namespace QuantConnect.DataProcessing
 
     public class NoNanRealConverter : JsonConverter
     {
-        public override bool CanWrite => False;
+        public override bool CanWrite => false;
         
         public override bool CanConvert(Type objectType)
         {

--- a/QuantConnect.DataSource.csproj
+++ b/QuantConnect.DataSource.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="QuantConnect.Common" Version="2.5.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/JsonConversionTests.cs
+++ b/tests/JsonConversionTests.cs
@@ -1,0 +1,70 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using QuantConnect.DataProcessing;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.DataLibrary.Tests
+{
+    [TestFixture]
+    public class JsonConversionTests
+    {
+        private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings
+        {
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc
+        };
+
+        [Test]
+        public void DeserializeQuiverWikipedia()
+        {
+            var content = "{" +
+                          "\"Date\":\"2020-01-01\"," +
+                          "\"Ticker\":\"ABBV\"," +
+                          "\"Views\":3500," +
+                          "\"pct_change_week\":3.2," +
+                          "\"pct_change_month\":6.75}";
+
+            var data = JsonConvert.DeserializeObject<QuiverWikipedia>(content, _jsonSerializerSettings);
+
+            Assert.NotNull(data);
+            Assert.AreEqual(new DateTime(2020, 01, 01, 0, 0, 0), data.Date);
+            Assert.AreEqual(3500, data.PageViews);
+            Assert.AreEqual(3.2, data.WeekPercentChange);
+            Assert.AreEqual(6.75, data.MonthPercentChange);
+        }
+
+        [Test]
+        public void DeserializeNaN()
+        {
+            _jsonSerializerSettings.Converters.Add(new NoNanRealConverter());
+
+            var content = "{" +
+                          "\"Date\":\"2020-01-01\"," +
+                          "\"Ticker\":\"ABBV\"," +
+                          "\"Views\":3500," +
+                          "\"pct_change_week\":NaN," +
+                          "\"pct_change_month\":NaN}";
+
+            var data = JsonConvert.DeserializeObject<QuiverWikipedia>(content, _jsonSerializerSettings);
+
+            Assert.IsNull(data.WeekPercentChange);
+            Assert.IsNull(data.MonthPercentChange);
+        }
+    }
+}

--- a/tests/QuiverWikipediaTests.cs
+++ b/tests/QuiverWikipediaTests.cs
@@ -15,7 +15,6 @@
 */
 
 using System;
-using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -27,30 +26,6 @@ namespace QuantConnect.DataLibrary.Tests
     [TestFixture]
     public class QuiverWikipediaTests
     {
-        private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings
-        {
-            DateTimeZoneHandling = DateTimeZoneHandling.Utc
-        };
-
-        [Test]
-        public void DeserializeQuiverWikipedia()
-        {
-            var content = "{" +
-                          "\"Date\":\"2020-01-01\"," +
-                          "\"Ticker\":\"ABBV\"," +
-                          "\"Views\":3500," +
-                          "\"pct_change_week\":3.2," +
-                          "\"pct_change_month\":6.75}";
-
-            var data = JsonConvert.DeserializeObject<QuiverWikipedia>(content, _jsonSerializerSettings);
-
-            Assert.NotNull(data);
-            Assert.AreEqual(new DateTime(2020, 01, 01, 0, 0, 0), data.Date);
-            Assert.AreEqual(3500, data.PageViews);
-            Assert.AreEqual(3.2, data.WeekPercentChange);
-            Assert.AreEqual(6.75, data.MonthPercentChange);
-        }
-
         [Test]
         public void QuiverWikipediaReader()
         {

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.9.4" />
-    <PackageReference Include="QuantConnect.Algorithm" Version="2.5.15788" />
+    <PackageReference Include="QuantConnect.Algorithm" Version="2.5.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\QuantConnect.DataSource.csproj" />

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -16,9 +16,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.9.4" />
-    <PackageReference Include="QuantConnect.Algorithm" Version="2.5.11800" />
+    <PackageReference Include="QuantConnect.Algorithm" Version="2.5.15788" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\QuantConnect.DataSource.csproj" />
+    <ProjectReference Include="..\DataProcessing\DataProcessing.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add json convertor to handle `NaN` in raw json, e.g.
```
{"Date": "2020-02-24", "Ticker": "AAN", "Views": 9.0, "pct_change_month": NaN, "pct_change_week": NaN}
```
which causes parsing issue in deserializing.

Added unit test on testing the JSON convertor that filter the `NaN`